### PR TITLE
[ADD] supported chain update in the thirdweb provider

### DIFF
--- a/app/ClientLayout.js
+++ b/app/ClientLayout.js
@@ -3,25 +3,10 @@
 import { ThemeProvider } from "next-themes";
 import { FaucetProvider } from "./contexts/FaucetContext";
 import { ThirdwebProvider, metamaskWallet, localWallet, walletConnect, phantomWallet, embeddedWallet } from "@thirdweb-dev/react";
+import { EtherlinkTestnet } from "@thirdweb-dev/chains"
 import "../public/css/tailwind.css";
 
-
 function ThirdWebConfig({ children }) {
-  const activeChain = {
-    chainId: 128123,
-    rpc: ["https://node.ghostnet.etherlink.com"],
-    nativeCurrency: {
-      decimals: 18,
-      name: "XTZ",
-      symbol: "XTZ",
-    },
-    shortName: "etherlink",
-    slug: "etherlink",
-    testnet: true,
-    chain: "Etherlink",
-    name: "Etherlink Testnet",
-  };
-
   const dAppMeta = {
     name: "Etherlink Testnet Faucet",
     description: "Drip Testnet XTZ",
@@ -32,7 +17,8 @@ function ThirdWebConfig({ children }) {
 
   return (
     <ThirdwebProvider clientId={process.env.THIRDWEB_CLIENT_ID}
-      activeChain={activeChain}
+      activeChain={EtherlinkTestnet}
+      supportedChains={[EtherlinkTestnet]}
       supportedWallets={[
         metamaskWallet({ recommended: true }),
         walletConnect(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@headlessui/react": "^1.7.14",
         "@heroicons/react": "^2.0.17",
         "@tailwindcss/aspect-ratio": "^0.4.2",
+        "@thirdweb-dev/chains": "^0.1.120",
         "@thirdweb-dev/react": "4.3.1",
         "@thirdweb-dev/sdk": "4.0.26",
         "@typeform/embed-react": "^3.8.0",
@@ -3714,6 +3715,14 @@
         "rlp": "^2.2.3"
       }
     },
+    "node_modules/@thirdweb-dev/auth/node_modules/@thirdweb-dev/chains": {
+      "version": "0.1.63",
+      "resolved": "https://registry.npmjs.org/@thirdweb-dev/chains/-/chains-0.1.63.tgz",
+      "integrity": "sha512-BFjoSLMzQZpC1R3DaMYhP+ySxRgVO/UCITLtJJom99oFlYKsOGCbjOsh0ubLc/LfvD+MPrWuCben3Rh2lBiuyA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@thirdweb-dev/auth/node_modules/@thirdweb-dev/wallets": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@thirdweb-dev/wallets/-/wallets-2.4.1.tgz",
@@ -3877,9 +3886,9 @@
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/@thirdweb-dev/chains": {
-      "version": "0.1.63",
-      "resolved": "https://registry.npmjs.org/@thirdweb-dev/chains/-/chains-0.1.63.tgz",
-      "integrity": "sha512-BFjoSLMzQZpC1R3DaMYhP+ySxRgVO/UCITLtJJom99oFlYKsOGCbjOsh0ubLc/LfvD+MPrWuCben3Rh2lBiuyA==",
+      "version": "0.1.120",
+      "resolved": "https://registry.npmjs.org/@thirdweb-dev/chains/-/chains-0.1.120.tgz",
+      "integrity": "sha512-6wj8eIylLk8wSyTUeN70LD72yN+QIwyynDfKtVGJXTcrEN2K+vuqnRE20gvA2ayX7KMyDyy76JxPlyv6SZyLGw==",
       "engines": {
         "node": ">=18"
       }
@@ -4059,6 +4068,14 @@
         "ethereum-cryptography": "^0.1.3",
         "ethjs-util": "0.1.6",
         "rlp": "^2.2.3"
+      }
+    },
+    "node_modules/@thirdweb-dev/react-core/node_modules/@thirdweb-dev/chains": {
+      "version": "0.1.63",
+      "resolved": "https://registry.npmjs.org/@thirdweb-dev/chains/-/chains-0.1.63.tgz",
+      "integrity": "sha512-BFjoSLMzQZpC1R3DaMYhP+ySxRgVO/UCITLtJJom99oFlYKsOGCbjOsh0ubLc/LfvD+MPrWuCben3Rh2lBiuyA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@thirdweb-dev/react-core/node_modules/@thirdweb-dev/wallets": {
@@ -4272,6 +4289,14 @@
         "rlp": "^2.2.3"
       }
     },
+    "node_modules/@thirdweb-dev/react/node_modules/@thirdweb-dev/chains": {
+      "version": "0.1.63",
+      "resolved": "https://registry.npmjs.org/@thirdweb-dev/chains/-/chains-0.1.63.tgz",
+      "integrity": "sha512-BFjoSLMzQZpC1R3DaMYhP+ySxRgVO/UCITLtJJom99oFlYKsOGCbjOsh0ubLc/LfvD+MPrWuCben3Rh2lBiuyA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@thirdweb-dev/react/node_modules/@thirdweb-dev/wallets": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@thirdweb-dev/wallets/-/wallets-2.4.1.tgz",
@@ -4476,6 +4501,14 @@
         "zksync-web3": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@thirdweb-dev/sdk/node_modules/@thirdweb-dev/chains": {
+      "version": "0.1.63",
+      "resolved": "https://registry.npmjs.org/@thirdweb-dev/chains/-/chains-0.1.63.tgz",
+      "integrity": "sha512-BFjoSLMzQZpC1R3DaMYhP+ySxRgVO/UCITLtJJom99oFlYKsOGCbjOsh0ubLc/LfvD+MPrWuCben3Rh2lBiuyA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@thirdweb-dev/sdk/node_modules/base-x": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@headlessui/react": "^1.7.14",
     "@heroicons/react": "^2.0.17",
     "@tailwindcss/aspect-ratio": "^0.4.2",
+    "@thirdweb-dev/chains": "^0.1.120",
     "@thirdweb-dev/react": "4.3.1",
     "@thirdweb-dev/sdk": "4.0.26",
     "@typeform/embed-react": "^3.8.0",


### PR DESCRIPTION
I noticed that the etherlink testnet was added manually instead of using the one created in the thirdweb chainlist and also that we haven't set the supported chain so now we can't see the other chains.