### PR TITLE
chore: bump minimum node version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,9 @@
         "lorem-ipsum": "^2.0.8",
         "postcss": "^8.4.23",
         "tailwindcss": "^3.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@account-abstraction/contracts": {

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "lorem-ipsum": "^2.0.8",
     "postcss": "^8.4.23",
     "tailwindcss": "^3.3.1"
+  },
+  "engines": {
+    "node": ">=20"
   }
 }


### PR DESCRIPTION
vercel has deprecated node 18